### PR TITLE
デプロイワークフローを修正

### DIFF
--- a/.github/workflows/continuous-delivery-workflow.yml
+++ b/.github/workflows/continuous-delivery-workflow.yml
@@ -7,12 +7,18 @@ on:
 jobs:
   deploy:
     name: deploy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - name: install
         run: |
           yarn install
-      - name: deploy
+      - name: build
         run: |
-          yarn run deploy
+          yarn run build
+      - name: deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: master
+          publish_dir: ./public


### PR DESCRIPTION
デプロイワークフローを修正した。
https://github.com/azujuuuuuun/azujuuuuuun.github.io/runs/713009640?check_suite_focus=true で GitHub Pages へのデプロイに失敗したので、https://github.com/marketplace/actions/github-pages-action を使うようにした。